### PR TITLE
Fix rust toolchain non-determinism

### DIFF
--- a/iso/musl-builder/Dockerfile
+++ b/iso/musl-builder/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH=/home/rust/.cargo/bin:/usr/local/musl/bin:/usr/local/bin:/usr/bin:/bin
 # `--target` to musl so that our users don't need to keep overriding it
 # manually.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    rustup default stable && \
+    rustup default 1.12.1 && \
     rustup target add x86_64-unknown-linux-musl
 ADD cargo-config.toml /home/rust/.cargo/config
 


### PR DESCRIPTION
Previously rustup would load the most recent stable version, which of course changes over time; now pinned to 1.12.1

Of course, this should all be changed with a local copy, but this is better than nothing.